### PR TITLE
Include serialport readline parser

### DIFF
--- a/nodeServer.js
+++ b/nodeServer.js
@@ -3,6 +3,7 @@
  */
 
 var SerialPort = require('SerialPort');
+const Readline = require('node_modules/@serialport/parser-readline')
 
 var app = require('http').createServer();
 var io = require('socket.io')(app);


### PR DESCRIPTION
Serialport readline parser include was missing, causing an error in the node.js terminal "serialport.parsers.readline is not a recognised function"